### PR TITLE
fix:(46):사용자 확인 부분 해결

### DIFF
--- a/src/main/java/com/example/Nadeuri/member/MemberEntity.kt
+++ b/src/main/java/com/example/Nadeuri/member/MemberEntity.kt
@@ -63,7 +63,7 @@ data class MemberEntity(
     }
 
     fun isNotWriter(name: String) =
-        this.name != name
+        this.userId != name
 
 }
 


### PR DESCRIPTION
## #️⃣관련 이슈
#46 

## 📝작업 내용
- 로그인한 사용자와 게시글 작성자가 같으면 해당 게시글을 수정 및 삭제가 가능하도록 올바르게 수정

## 💬리뷰 요구사항(선택)
> 로그인한 사용자를 확인할 때 `authentication.name`로 확인하고 있습니다. 하지만 이는 MemberEntity에서 name이 아닌 userId였습니다. 조금 더 의미있는 변수명과 데이터 타입으로 리팩토링할 필요성을 느꼈습니다.  
