### PR TITLE
fix : 뷰 리졸버 에러 및 authorization=null 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
     implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
 
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
     // JWT 관련 의존성
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/com/example/Nadeuri/board/kotlin/controller/BoardViewController2.kt
+++ b/src/main/java/com/example/Nadeuri/board/kotlin/controller/BoardViewController2.kt
@@ -29,7 +29,7 @@ class BoardViewController2(
         val boards: Page<BoardReadResponse2> = boardService.page(boardPageRequestDTO)
         model.addAttribute("boards", boards.content)
         model.addAttribute("page", boards)
-        return "list" // list.html로 이동
+        return "board/list" // list.html로 이동
     }
 
     //게시글 상세 조회

--- a/src/main/java/com/example/Nadeuri/member/config/SecurityConfig.kt
+++ b/src/main/java/com/example/Nadeuri/member/config/SecurityConfig.kt
@@ -44,8 +44,7 @@ class SecurityConfig(
             // 특정 API에 대한 인증 요구
             .authorizeHttpRequests { authorize ->
                 authorize
-                    .requestMatchers("/api/token", "/error").permitAll() // 토큰 발급 요청은 모두 허용
-                    .requestMatchers("/api/**").authenticated() // 나머지 API는 인증 필요
+                    .requestMatchers("/api/token").permitAll() // 토큰 발급 요청은 모두 허용
                     .anyRequest().permitAll() // 그 외 요청은 모두 허용
             }
             // 인증 예외 처리

--- a/src/main/java/com/example/Nadeuri/member/controller/MemberController.kt
+++ b/src/main/java/com/example/Nadeuri/member/controller/MemberController.kt
@@ -14,7 +14,6 @@ import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
-import org.modelmapper.ModelMapper
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -28,7 +27,6 @@ class MemberController(
     private val memberRepository: MemberRepository,
     private val passwordEncoder: PasswordEncoder,
     private val jwtUtil: JWTUtil,
-    private val modelMapper: ModelMapper
 ) {
 
     companion object {
@@ -60,8 +58,8 @@ class MemberController(
 
         // 토큰 생성
         val payloadMap = foundMemberDTO.getPayload()
-        val accessToken = jwtUtil.createToken(payloadMap, 1)
-        val refreshToken = jwtUtil.createToken(mapOf("userId" to foundMemberDTO.userId), 1)
+        val accessToken = jwtUtil.createToken(payloadMap, 120)
+        val refreshToken = jwtUtil.createToken(mapOf("userId" to foundMemberDTO.userId), 180)
 
         // 쿠키에 토큰 저장
         CookieUtil.addCookie(response, "accessToken", accessToken, 3600)
@@ -84,6 +82,7 @@ class MemberController(
         log.info(dbUserId)
 
         if (authentication.name != userId || dbUserId != userId) { // 인증 사용자와 DTO의 사용자가 불일치
+            log.info(authentication.name)
             throw MemberException.NOT_MATCHED_USER.get()
         }
 

--- a/src/main/java/com/example/Nadeuri/member/controller/MemberViewController.kt
+++ b/src/main/java/com/example/Nadeuri/member/controller/MemberViewController.kt
@@ -5,7 +5,6 @@ import com.example.Nadeuri.member.dto.MemberDTO
 import com.example.Nadeuri.member.dto.request.MemberUpdateRequest
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import lombok.RequiredArgsConstructor
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler
@@ -45,7 +44,7 @@ class MemberViewController(private val memberService: MemberService) {
 
         val memberDTO = MemberDTO(memberService.findByUserId(userId))
         model.addAttribute("member", memberDTO)
-        return "member/edit"  // 회원정보 수정 페이지로 이동 (Thymeleaf 템플릿 등)
+        return "members/edit"  // 회원정보 수정 페이지로 이동 (Thymeleaf 템플릿 등)
     }
 
     // 회원정보 수정 처리

--- a/src/main/java/com/example/Nadeuri/member/security/filter/JWTCheckFilter.kt
+++ b/src/main/java/com/example/Nadeuri/member/security/filter/JWTCheckFilter.kt
@@ -37,8 +37,9 @@ class JWTCheckFilter(
             request.requestURI.startsWith("/v1/members/login") -> true
             request.requestURI.startsWith("/members/sign-up") -> true
             request.requestURI.startsWith("/members/login") -> true
-            request.requestURI.startsWith("/boards/list") -> true
+            request.requestURI.startsWith("/board/list") -> true
             request.requestURI.startsWith("/img/") -> true
+
             request.requestURI == "/v1/boards" -> true
             request.requestURI == "/boards/" -> true
             else -> false
@@ -54,17 +55,27 @@ class JWTCheckFilter(
         log.info("--- doFilterInternal()")
         log.info("--- requestURI : ${request.requestURI}")
 
-        val headerAuth = request.getHeader("Authorization")
-        log.info("--- headerAuth : $headerAuth")
+        // 쿠키에서 토큰 값을 가져와야 하므로 쿠키에서 액세스 토큰 검색
+        var accessToken: String? = null
+        val cookies = request.cookies
+        if (cookies != null) {
+            for (cookie in cookies) {
+                if (cookie.name == "accessToken") {
+                    accessToken = cookie.value
+                    break
+                }
+            }
+        }
 
-        // 액세스 토큰이 없거나 'Bearer ' 가 아니면 403 예외 발생
-        if (headerAuth == null || !headerAuth.startsWith("Bearer ")) {
+        log.info("--- accessToken : $accessToken")
+
+        // 액세스 토큰이 없으면 403 예외 발생
+        if (accessToken == null) {
             handleException(response, Exception("ACCESS TOKEN NOT FOUND"))
             return
         }
 
         // 토큰 유효성 검증
-        val accessToken = headerAuth.substring(7) // "Bearer " 를 제외하고 토큰값 저장
         try {
             val claims = jwtUtil.validateToken(accessToken)
             log.info("--- 토큰 유효성 검증 완료 ---")

--- a/src/main/resources/templates/board/list.html
+++ b/src/main/resources/templates/board/list.html
@@ -236,9 +236,9 @@
         window.location.href = '/members/logout';
     });
 
-    // 게시물 작성 버튼 클릭 시 /boards/create 페이지로 이동
+    // 게시물 작성 버튼 클릭 시 /board/create 페이지로 이동
     document.getElementById('createPostButton').addEventListener('click', function() {
-        window.location.href = '/boards/create';
+        window.location.href = '/board/create';
     });
 
     // 회원정보 수정 버튼 클릭 시 /members/edit 페이지로 이동

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -106,7 +106,7 @@
         })
         .then(function(response) {
             alert('로그인 성공!');
-            window.location.href = '/boards/list'; // 로그인 후 게시물 목록 페이지로 리디렉션
+            window.location.href = '/board/list'; // 로그인 후 게시물 목록 페이지로 리디렉션
         })
         .catch(function(error) {
             const errorMessage = error.response && error.response.data && error.response.data.message


### PR DESCRIPTION

## #️⃣관련 이슈
#52 

## 📝작업 내용
뷰 리졸버 에러 => build.gradle에 타임리프 추가하여 해결하였습니다.
요청헤더 headerAuth값이 null로 찍히는 문제 => 쿠키에서 토큰 값을 가져오는 방식으로 수정

### 스크린샷 추가(선택)
![image](https://github.com/user-attachments/assets/641da82b-1f8d-4ac2-b91b-08482c78e362)
이제 postman에서 헤더의 쿠키 안에 토큰값이 저장되어 요청되므로  따로 authorization헤더를 추가하지 않으셔도 됩니다 !
그대신 로그인하시고 쿠키 안에 토큰 값이 정상적으로 바뀌는지만 확인해주세요 !

## 💬리뷰 요구사항(선택)
쿠키에 토큰값을 저장하는 방식에 대한 여러분의 의견이 궁금합니다 !! 더 개선할 부분이 있다면 말씀해주세요 !
