### PR TITLE
fix : view html파일 수정, Board 수정

### DIFF
--- a/src/main/java/com/example/Nadeuri/board/kotlin/controller/BoardViewController2.kt
+++ b/src/main/java/com/example/Nadeuri/board/kotlin/controller/BoardViewController2.kt
@@ -5,6 +5,8 @@ import com.example.Nadeuri.board.kotlin.controller.dto.BoardPageRequestDTO2
 import com.example.Nadeuri.board.kotlin.controller.dto.BoardReadResponse2
 import com.example.Nadeuri.board.kotlin.service.BoardService2
 import com.example.Nadeuri.member.MemberService
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
 import org.springframework.data.domain.Page
 import org.springframework.security.core.Authentication
 import org.springframework.stereotype.Controller
@@ -19,6 +21,9 @@ class BoardViewController2(
     private val boardService: BoardService2,
     private val memberService: MemberService
 ) {
+    companion object {
+        private val log: Logger = LogManager.getLogger(BoardService2::class.java)
+    }
 
     /**
      * 게시글 목록 페이지
@@ -29,6 +34,7 @@ class BoardViewController2(
         val boards: Page<BoardReadResponse2> = boardService.page(boardPageRequestDTO)
         model.addAttribute("boards", boards.content)
         model.addAttribute("page", boards)
+        log.info("boardController() list")
         return "board/list" // list.html로 이동
     }
 
@@ -57,8 +63,10 @@ class BoardViewController2(
         @RequestParam image: MultipartFile,
         authentication: Authentication
     ): String {
+        log.info("controller()")
         // Authentication 객체에서 username 추출
         val userId: String = authentication.name // username 가져오기
+        log.info("userId =" +userId)
         val memberId: Long = memberService.findByUserId(userId).memberNo // username으로 memberId 조회
         val updatedRequest = BoardCreateRequest2(
             memberId,
@@ -69,6 +77,6 @@ class BoardViewController2(
 
         // 게시글 등록 처리
         boardService.register(updatedRequest, image)
-        return "redirect:/boards/list" // 게시글 목록 페이지로 리다이렉트
+        return "redirect:/board/list" // 게시글 목록 페이지로 리다이렉트
     }
 }

--- a/src/main/java/com/example/Nadeuri/board/kotlin/controller/dto/BoardCreateRequest2.kt
+++ b/src/main/java/com/example/Nadeuri/board/kotlin/controller/dto/BoardCreateRequest2.kt
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotNull
 
 data class BoardCreateRequest2(
     @NotNull(message = "회원만 게시글을 작성할 수 있습니다.")
-    val memberId: Long,
+    val memberId: Long?,
 
     @NotBlank(message = "제목을 확인해주세요. 빈값 혹은 null 일 수 없습니다.")
     val boardTitle: String,

--- a/src/main/java/com/example/Nadeuri/board/kotlin/service/BoardService2.kt
+++ b/src/main/java/com/example/Nadeuri/board/kotlin/service/BoardService2.kt
@@ -42,14 +42,16 @@ class BoardService2(
         request: BoardCreateRequest2,
         boardImage: MultipartFile?,
     ) {
-
+        log.info("service()")
         val imageUrl = if (boardImage == null || boardImage.isEmpty) {
             "$uploadPath/defaultImage.png"
         } else {
             imageRepository2.upload(boardImage)
         }
 
-        val member: MemberEntity = retrieveMember(request.memberId)
+        val memberId = request.memberId ?: throw IllegalArgumentException("memberId는 필수 값입니다.")
+        val member: MemberEntity = retrieveMember(memberId)
+
 
         try {
             val board = BoardEntity.create(
@@ -75,10 +77,13 @@ class BoardService2(
 
     // 게시글 전체 조회
     fun page(boardPageRequestDTO: BoardPageRequestDTO2): Page<BoardReadResponse2> {
-        return try {
+        try {
+            log.info("page service()")
             val sort = Sort.by("id").ascending()
             val pageable = boardPageRequestDTO.getPageable(sort)
-            boardRepository2.pageDTO(pageable)
+            val pageDTO = boardRepository2.pageDTO(pageable)
+            log.info(pageDTO.totalElements)
+            return pageDTO
         } catch (e: Exception) {
             throw BoardException2.NOT_FOUND.get()
         }

--- a/src/main/resources/templates/board/create.html
+++ b/src/main/resources/templates/board/create.html
@@ -31,7 +31,7 @@
     <div class="card bg-light col-md-8 p-4">
         <div class="card-body">
             <h1 class="text-dark">게시글 등록</h1>
-            <form action="#" th:action="@{/boards/create}" method="post" enctype="multipart/form-data">
+            <form action="#" th:action="@{/board/create}" method="post" enctype="multipart/form-data">
                 <div class="form-group">
                     <label for="boardTitle">제목:</label>
                     <input type="text" id="boardTitle" name="boardTitle" class="form-control" required>
@@ -43,8 +43,8 @@
                 </div>
 
                 <div class="form-group">
-                    <label for="category">카테고리:</label>
-                    <select id="category" name="category" class="form-control" required>
+                    <label for="category2">카테고리:</label>
+                    <select id="category2" name="category2" class="form-control" required>
                         <option value="FOOD">먹거리</option>
                         <option value="PLAY">놀거리</option>
                         <!-- 더 많은 카테고리 추가 가능 -->

--- a/src/main/resources/templates/board/list.html
+++ b/src/main/resources/templates/board/list.html
@@ -60,8 +60,6 @@
                 <button id="logoutButton" class="btn btn-danger logout-button">로그아웃</button>
 
                 <div id="userInfoContainer" class="user-info" style="display: none;">
-                    <img id="userProfileImage" src="" alt="Profile Picture">
-                    <span id="userNameDisplay"></span>
                     <button id="editProfileButton" class="btn btn-info btn-sm" style="margin-left: 10px;">회원정보 수정</button>
                 </div>
             </div>
@@ -136,7 +134,7 @@
 
     function loadPosts(page) {
         currentPage = page;
-        fetch(`/v1/boards?page=${page}&size=${postsPerPage}`)
+        fetch(`/v2/boards?page=${page}&size=${postsPerPage}`)
             .then(response => response.json())
             .then(responseData => {
                 const postsData = responseData.data;
@@ -214,8 +212,6 @@
                 const userName = userInfo.name;
                 const profileImage = userInfo.profileImage;
 
-                document.getElementById('userNameDisplay').innerText = userName;
-                document.getElementById('userProfileImage').src = profileImage;
                 document.getElementById('userInfoContainer').style.display = 'flex';
             }
         } else {

--- a/src/main/resources/templates/members/edit.html
+++ b/src/main/resources/templates/members/edit.html
@@ -13,11 +13,6 @@
         <!-- 숨겨진 필드로 PUT 메서드 처리 -->
         <input type="hidden" name="_method" value="put" />
 
-        <!-- 비밀번호 수정 -->
-        <div class="form-group">
-            <label for="password">비밀번호</label>
-            <input type="password" class="form-control" id="password" name="password" th:value="${member.password}" required>
-        </div>
 
         <!-- 이름 수정 -->
         <div class="form-group">
@@ -52,15 +47,6 @@
             <input type="file" class="form-control-file" id="profileImage" name="profileImage">
             <img th:src="@{${member.profileImage}}" alt="Profile Image" class="img-fluid mt-3" style="max-width: 200px;">
         </div>
-
-        <!-- 생년월일 확인 (수정 불가) -->
-        <div class="form-group">
-            <label for="birthDate">생년월일</label>
-            <p id="birthDate" class="form-control-plaintext" th:text="${member.birthDate}"></p>
-        </div>
-
-        <button type="submit" class="btn btn-primary">수정하기</button>
-    </form>
 
     <!-- 성공 메시지 -->
     <div th:if="${message}" class="alert alert-success mt-3" role="alert">

--- a/src/main/resources/templates/members/edit.html
+++ b/src/main/resources/templates/members/edit.html
@@ -48,6 +48,9 @@
             <img th:src="@{${member.profileImage}}" alt="Profile Image" class="img-fluid mt-3" style="max-width: 200px;">
         </div>
 
+        <button type="submit" class="btn btn-primary">수정하기</button>
+    </form>
+
     <!-- 성공 메시지 -->
     <div th:if="${message}" class="alert alert-success mt-3" role="alert">
         <span th:text="${message}"></span>


### PR DESCRIPTION
## fix : view html파일 수정, Board 수정

## #️⃣관련 이슈
#54 

## 📝작업 내용
- html 파일 수정
- 1.create.html,list.html,edit.html 파일 수정
> 엔드포인트 이름이 변경되어 맞게 수정하였습니다
- 2. Board service,controller수정
> 유효성 검사중 memberid를 검사할 때 컨트롤러까지 넘어가야 Authentication에서 유저의 정보를 받아와야하는데 service에서 바로 예외처리되는 버그를 수정하였습니다(스크린샷 첨부)

### 스크린샷 추가(선택)
![컨트롤러 서비스](https://github.com/user-attachments/assets/71ad28cf-ca22-437d-9375-04d7ee61d617)

### 다음 작업
 - 페이지네이션 기능
 > 페이지네이션 동작이 안되는 버그 발생
 - 회원 정보 수정 기능
 > memberUpdateRequest에 널값이 들어가 예외가 발생, 작업 내용2와 같은 오류
